### PR TITLE
Add Tag to Drafts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'font-awesome-sass', '~> 4.7.0'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'bootswatch-rails'
 gem 'jquery-rails'
+gem 'acts-as-taggable-on', '~> 5.0'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (5.0.0)
+      activerecord (>= 4.2.8)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
@@ -295,6 +297,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 5.0)
   bootstrap-sass (~> 3.3.6)
   bootswatch-rails
   byebug
@@ -333,4 +336,4 @@ DEPENDENCIES
   will_paginate (~> 3.1.0)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/app/assets/stylesheets/components/_draft_list_item.scss
+++ b/app/assets/stylesheets/components/_draft_list_item.scss
@@ -25,3 +25,8 @@
   bottom: 0px;
   right: 0px;
 }
+
+.draft-list-item .tag-list{
+  float: left;
+  font-size: 92%;
+}

--- a/app/assets/stylesheets/components/_tag_list.scss
+++ b/app/assets/stylesheets/components/_tag_list.scss
@@ -1,0 +1,14 @@
+.tag-list{
+  padding: 0px;
+  list-style-type: none;
+  display: inline;
+  text-align: left;
+}
+
+.tag-list__item{
+  display: inline;
+  margin-right: 2px;
+  padding: 1px 3px;
+  color: rgb(145, 23, 10);
+  text-decoration: underline;
+}

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -43,6 +43,6 @@ class DraftsController < ApplicationController
   end
 
   def draft_params
-    params.require(:draft).permit(:title, :content)
+    params.require(:draft).permit(:title, :content, :tag_list)
   end
 end

--- a/app/javascript/home_page/components/draft_list_item.jsx
+++ b/app/javascript/home_page/components/draft_list_item.jsx
@@ -9,8 +9,18 @@ class DraftListItem extends Component{
     let elapsed = new Elapsed(new Date(this.props.created_at), new Date());
     return(elapsed.optimal)
   }
+  renderTagList(){
+    let tagListItems = this.props.tag_list.map((tag, index) =>{
+      return(<li key={index} className='tag-list__item'>{tag}</li>)
+    })
+
+    if(tagListItems.length){
+      return(<ul className='tag-list'>{tagListItems}</ul>)
+    }else{
+      return(<small className='pull-left'>No tag</small>)
+    }
+  }
   render(){
-    let elapsed = new Date()
     return(
       <div className='draft-list-item panel'>
         <div className='draft-list-item__title'>
@@ -20,6 +30,7 @@ class DraftListItem extends Component{
           {this.props.content_preview}
         </div>
         <div className='draft-list-item__footer text-right'>
+          {this.renderTagList()}
           <small className='draft-list-item__metadata'>
             {this.elapsedTime()}
           </small>

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -6,6 +6,8 @@ class Draft < ApplicationRecord
 
   scope :latest_first, ->{order(created_at: :desc)}
 
+  acts_as_taggable
+
   def content_preview
     renderer = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
     renderer.render(content).html_safe.truncate(50)

--- a/app/views/drafts/_form_fields.html.slim
+++ b/app/views/drafts/_form_fields.html.slim
@@ -1,0 +1,5 @@
+= f.text_field :title, class: 'form-control', autofocus: true, required: true, placeholder: 'Draft title'
+br
+= f.text_area :content, id: 'markdown-editor'
+br
+= f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma', value: f.object.tag_list.to_s

--- a/app/views/drafts/edit.html.slim
+++ b/app/views/drafts/edit.html.slim
@@ -5,6 +5,9 @@ hr
   = f.text_field :title, class: 'form-control', autofocus: true, required: true, placeholder: 'Draft title'
   br
   = f.text_area :content, id: 'markdown-editor'
+  br
+  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma', value: f.object.tag_list.to_s
+  br
   .text-center
     .btn-group
       = f.submit 'Update draft', class: 'btn btn-primary'

--- a/app/views/drafts/edit.html.slim
+++ b/app/views/drafts/edit.html.slim
@@ -2,11 +2,7 @@ h3 Edit Draft
 hr
 
 = form_for @draft, method: :put do |f|
-  = f.text_field :title, class: 'form-control', autofocus: true, required: true, placeholder: 'Draft title'
-  br
-  = f.text_area :content, id: 'markdown-editor'
-  br
-  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma', value: f.object.tag_list.to_s
+  = render "form_fields", {f: f}
   br
   .text-center
     .btn-group

--- a/app/views/drafts/edit.html.slim
+++ b/app/views/drafts/edit.html.slim
@@ -2,7 +2,7 @@ h3 Edit Draft
 hr
 
 = form_for @draft, method: :put do |f|
-  = render "form_fields", {f: f}
+  = render 'form_fields', {f: f}
   br
   .text-center
     .btn-group

--- a/app/views/drafts/new.html.slim
+++ b/app/views/drafts/new.html.slim
@@ -2,7 +2,7 @@ h3 New Draft
 hr
 
 = form_for @draft do |f|
-  = render "form_fields", {f: f}
+  = render 'form_fields', {f: f}
   br
   .text-center
     .btn-group

--- a/app/views/drafts/new.html.slim
+++ b/app/views/drafts/new.html.slim
@@ -2,11 +2,7 @@ h3 New Draft
 hr
 
 = form_for @draft do |f|
-  = f.text_field :title, class: 'form-control', autofocus: true, required: true, placeholder: 'Draft title'
-  br
-  = f.text_area :content, id: 'markdown-editor'
-  br
-  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma', value: f.object.tag_list.to_s
+  = render "form_fields", {f: f}
   br
   .text-center
     .btn-group

--- a/app/views/drafts/new.html.slim
+++ b/app/views/drafts/new.html.slim
@@ -5,6 +5,8 @@ hr
   = f.text_field :title, class: 'form-control', autofocus: true, required: true, placeholder: 'Draft title'
   br
   = f.text_area :content, id: 'markdown-editor'
+  br
+  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma'
   .text-center
     .btn-group
       = f.submit 'Save draft', class: 'btn btn-primary'

--- a/app/views/drafts/new.html.slim
+++ b/app/views/drafts/new.html.slim
@@ -6,7 +6,8 @@ hr
   br
   = f.text_area :content, id: 'markdown-editor'
   br
-  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma'
+  = f.text_field :tag_list, class: 'form-control', placeholder: 'Tags separated by comma', value: f.object.tag_list.to_s
+  br
   .text-center
     .btn-group
       = f.submit 'Save draft', class: 'btn btn-primary'

--- a/app/views/drafts/show.html.slim
+++ b/app/views/drafts/show.html.slim
@@ -5,8 +5,15 @@
     .draft-page__content
       = markdown_to_html(@draft.content)
       .clearfix
-
-    .draft-page__footer.text-center
-      .btn-group
-        = link_to 'Edit', edit_draft_path(@draft), class: 'btn btn-info'
-        = link_to 'Delete', draft_path(@draft), method: :delete, class: 'btn btn-danger', data: {confirm: 'Are you sure you want to delete this draft?'}
+      br
+      br
+      span.small Tags:
+      br
+      ul.tag-list.small
+       - @draft.tag_list.each do |tag|
+         li.tag-list__item= tag
+    .draft-page__footer
+      .text-center
+        .btn-group
+          = link_to 'Edit', edit_draft_path(@draft), class: 'btn btn-info'
+          = link_to 'Delete', draft_path(@draft), method: :delete, class: 'btn btn-danger', data: {confirm: 'Are you sure you want to delete this draft?'}

--- a/app/views/home/show.html.slim
+++ b/app/views/home/show.html.slim
@@ -1,2 +1,2 @@
 .row
-  #home-page.home-page data-drafts="#{@home.drafts.to_json(methods: :content_preview)}"
+  #home-page.home-page data-drafts="#{@home.drafts.to_json(methods: [:content_preview, :tag_list])}"

--- a/db/migrate/20171016135832_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135832_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20171016135833_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135833_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20171016135834_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135834_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20171016135835_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135835_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20171016135836_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135836_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20171016135837_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171016135837_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412070656) do
+ActiveRecord::Schema.define(version: 20171016135837) do
 
   create_table "drafts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "content"
@@ -20,6 +20,31 @@ ActiveRecord::Schema.define(version: 20170412070656) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_drafts_on_user_id"
+  end
+
+  create_table "taggings", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name", collation: "utf8_bin"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/features/creating_a_draft_spec.rb
+++ b/spec/features/creating_a_draft_spec.rb
@@ -14,6 +14,7 @@ feature 'drafts', js: true do
     expect(page).to have_selector('.CodeMirror')
 
     fill_in('draft_title', with: 'Draft#1')
+    fill_in('draft_tag_list', with: 'ruby_tag, javascript_tag')
     fill_in_editor_field('**Hello World**')
     expect(page).to have_editor_display text: 'Hello World'
     click_button 'Save draft'
@@ -21,6 +22,8 @@ feature 'drafts', js: true do
     expect(page).to have_current_path('/')
     expect(page).to have_selector('.flash--success')
     expect(page).to have_selector('.draft-list-item', count: 1)
+    expect(page).to have_content('ruby_tag')
+    expect(page).to have_content('javascript_tag')
   end
 
 

--- a/spec/features/managing_existing_draft_spec.rb
+++ b/spec/features/managing_existing_draft_spec.rb
@@ -16,6 +16,7 @@ feature 'Managing existing draft', :js do
     click_on('Edit')
     expect(page.current_path).to eq(edit_draft_path(draft))
     fill_in('draft_title', with: 'TUGS for long term')
+    fill_in('draft_tag_list', with: 'design_tag, art_tag')
 
     fill_in_editor_field(new_content)
     expect(page).to have_editor_display(text: new_content)
@@ -23,6 +24,8 @@ feature 'Managing existing draft', :js do
 
     expect(page.current_path).to eq(draft_path(draft))
     expect(page).to have_content(new_content.gsub('*', ''))
+    expect(page).to have_content('design_tag')
+    expect(page).to have_content('art_tag')
     expect(page).to have_content('have been updated')
   end
 

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -22,4 +22,9 @@ RSpec.describe Draft, type: :model do
       expect(draft.content_preview).to eq "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
     end
   end
+
+  describe 'Taggable' do
+    it {is_expected.to(respond_to(:tags))}
+    it {is_expected.to(respond_to(:tag_list))}
+  end
 end


### PR DESCRIPTION
Fixes #3 

- Uses acts_as_taggable_on gem for the tag function
- Now able to add/edit tags on draft